### PR TITLE
Add a basic walking animation, based on the Minecraft Classic one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/example/main.js
+++ b/example/main.js
@@ -14,5 +14,7 @@ substack.possess();
 window.addEventListener('keydown', function (ev) {
     if (ev.keyCode === 'R'.charCodeAt(0)) {
         substack.toggle();
+    } else if (ev.keyCode === 'T'.charCodeAt(0)) {
+        substack.toggleAnimation();
     }
 });

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ module.exports = function (game) {
         game.control(physics);
 
         if (opts.animate) {
-            var leftArmBaseRotation = playerSkin.leftArm.rotation.z,
+            var oldTick = physics.tick,
+                leftArmBaseRotation = playerSkin.leftArm.rotation.z,
                 rightArmBaseRotation = playerSkin.rightArm.rotation.z,
                 leftLegBaseRotation = playerSkin.leftLeg.rotation.z,
                 rightLegBaseRotation = playerSkin.rightLeg.rotation.z,
@@ -45,6 +46,9 @@ module.exports = function (game) {
                 animationRunning = false,
                 animationShouldStop = false;
             physics.tick = function (dt) {
+                if (oldTick !== undefined) {
+                    oldTick.call(physics, dt);
+                }
                 if (!animationRunning) {
                     return;
                 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -13,16 +13,23 @@ var game = createGame({
 window.game = game;
 game.appendTo('#container');
 
-var createPlayer = require('voxel-player')(game);
+var createPlayer = require('../')(game);
 var substack = createPlayer('substack.png');
+substack.position.y = 1000;
 substack.possess();
 
 window.addEventListener('keydown', function (ev) {
     if (ev.keyCode === 'R'.charCodeAt(0)) {
         substack.toggle();
+    } else if (ev.keyCode === 'T'.charCodeAt(0)) {
+        substack.toggleAnimation();
     }
 });
 ```
+
+# running the example
+
+Create a `node_modules/` folder in the root of the `voxel-player/` directory, and use npm to install the dependencies. Assuming you've installed browserify globally, run `browserify main.js > static/bundle.js` in the `example/` directory, then run `node server.js` and visit `localhost:8085` in your browser. If you're using Chrome, make sure to clear cache after making any modifications to prevent it from caching `bundle.js`.
 
 # methods
 
@@ -77,6 +84,18 @@ Toggle the player pov between 1st and 3rd.
 ## player.possess()
 
 Set the player as the active camera view.
+
+## player.startAnimation()
+
+Starts the player walking animation. Does nothing if animation is disabled.
+
+## player.stopAnimation()
+
+Gracefully stops the player walking animation, by letting it run to completion. Does nothing if animation is disabled.
+
+## player.toggleAnimation()
+
+Depending on the current animation state, either starts or stops the animation. Does nothing if animation is disabled.
 
 # install
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -41,12 +41,12 @@ Return a new player from a image file src string `img`.
 `skinOpts` are an options object passed through to the [minecraft-skin](https://github.com/maxogden/minecraft-skin) module.
 `opts` are an options object used to control animation parameters:
 
-    * `animate`: Whether to animate the player object at all (default: true)
-    * `animationSpeed`: Time for one cycle of animation to complete, in seconds (default: 1 second)
-    * `animationAmount`: How far the body segments rotate, as a multiple of 180 degrees (default: 0.5 / 90 degrees)
-    * `legAmount`: How far the leg segments rotate, as a multiple of `animationAmount` (default: 1.0)
-    * `armAmount`: Similar, but for the arm segments (default: 1.0)
-    * `headAmount`: Also similar, but for the head segment (default: 0.25)
+* `animate`: Whether to animate the player object at all (default: true)
+* `animationSpeed`: Time for one cycle of animation to complete, in seconds (default: 1 second)
+* `animationAmount`: How far the body segments rotate, as a multiple of 180 degrees (default: 0.5 / 90 degrees)
+* `legAmount`: How far the leg segments rotate, as a multiple of `animationAmount` (default: 1.0)
+* `armAmount`: Similar, but for the arm segments (default: 1.0)
+* `headAmount`: Also similar, but for the head segment (default: 0.25)
 
 ## player.position.set(x, y, z)
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -35,9 +35,18 @@ var voxelPlayer = require('voxel-player')
 Return a function `createPlayer` from a
 [voxel-engine](https://github.com/maxogden/voxel-engine) `game` instance.
 
-## var player = createPlayer(img)
+## var player = createPlayer(img, skinOpts, opts)
 
 Return a new player from a image file src string `img`.
+`skinOpts` are an options object passed through to the [minecraft-skin](https://github.com/maxogden/minecraft-skin) module.
+`opts` are an options object used to control animation parameters:
+
+    * `animate`: Whether to animate the player object at all (default: true)
+    * `animationSpeed`: Time for one cycle of animation to complete, in seconds (default: 1 second)
+    * `animationAmount`: How far the body segments rotate, as a multiple of 180 degrees (default: 0.5 / 90 degrees)
+    * `legAmount`: How far the leg segments rotate, as a multiple of `animationAmount` (default: 1.0)
+    * `armAmount`: Similar, but for the arm segments (default: 1.0)
+    * `headAmount`: Also similar, but for the head segment (default: 0.25)
 
 ## player.position.set(x, y, z)
 


### PR DESCRIPTION
The perfectly-straight limbs in the demo were kind of creeping me out, so I added some basic wacky arm waving similar to the animation that existed in Minecraft Classic. There's an option to totally disable it, for people that want to avoid the (small) performance cost of an additional callback on `tick()`.

Let me know if there's any issues with this pull request I should fix.

(Also, is there a reason the example puts the player 1000 blocks in the sky?)
